### PR TITLE
Update to Foundation Sites 6.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Foundation Font Awesome Buttons
-![Foundation Version Supported Version](https://img.shields.io/badge/Foundation-v6.0.4-blue.svg?style=flat-square)
+![Foundation Version Supported Version](https://img.shields.io/badge/Foundation-v6.1.2-blue.svg?style=flat-square)
 ![Font Awesome Supported Version](https://img.shields.io/badge/Font_Awesome-v4.5.0-green.svg?style=flat-square)
 
 Foundation Icon Buttons combines the Zurb's Foundation with the Font Awesome project. Building stylish icon buttons is quick and easy.

--- a/bower.json
+++ b/bower.json
@@ -15,8 +15,8 @@
     "scss"
   ],
   "dependencies": {
-    "foundation-sites": "~6.0.5",
-    "fontawesome": "~4.5.0"
+    "foundation-sites": "6.1.2",
+    "fontawesome": "4.5.0"
   },
   "license": "MIT",
   "homepage": "https://github.com/joshmedeski/foundation-font-awesome-buttons"


### PR DESCRIPTION
Updated to Foundation Sites version 6.1.2 and locked the Bower versions for all dependencies.
