### PR TITLE
Refactoring & Bug Fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Foundation Font Awesome Buttons</title>
   <link rel="stylesheet" href="../css/preview.css">
+  <style>
+    .dark-background {
+      background: #27313d;
+      display: inline-block;
+      padding: 20px;
+    }
+    .dark-background .button {
+      margin-bottom: 0;
+    }
+  </style>
 </head>
 <body>
   <div class="row">
@@ -82,6 +92,11 @@
       <div class="button-group">
         <a class="[ button ][ ffab fa-group ]">Button Group</a>
         <a class="[ button ][ ffab fa-group ]">Button Group</a>
+      </div>
+      <div class="dark-background">
+        <a href="#" class="[ hollow button ][ ffab fa-star ]">Hollow</a>
+        <a href="#" class="[ hollow button ][ ffab fa-star cover ]">Hollow</a>
+        <a href="#" class="[ hollow button ][ ffab fa-star static ]">Hollow</a>
       </div>
       <hr>
       <strong>Utilities</strong>

--- a/src/_ffab-base.scss
+++ b/src/_ffab-base.scss
@@ -3,16 +3,9 @@
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 @mixin ffab-base {
-  overflow: hidden;
-  position: relative;
-}
-
-@mixin ffab-icon {
-  &::before {
-    @include fa-icon;
-    line-height: 1;
-    position: absolute;
+  .#{$ffab-css-prefix} {
+    overflow: hidden;
+    position: relative;
     transition: all $ffab-transition-speed;
-    z-index: 2;
   }
 }

--- a/src/_ffab-bordered.scss
+++ b/src/_ffab-bordered.scss
@@ -1,0 +1,9 @@
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Bordered (ffab)
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+@mixin ffab-bordered {
+  .#{$ffab-css-prefix}.bordered {
+    @include ffab-overlay(1px);
+  }
+}

--- a/src/_ffab-hollow.scss
+++ b/src/_ffab-hollow.scss
@@ -1,0 +1,17 @@
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Hollow (ffab)
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+@mixin ffab-hollow {
+  .#{$ffab-css-prefix}.hollow {
+    @include ffab-overlay(1px, transparent);
+    &.static::after {
+      transition: border-color 0.25s ease-out;
+    }
+    @if ($ffab-transition-behavior == 'static') {
+      &::after {
+        transition: border-color 0.25s ease-out;
+      }
+    }
+  }
+}

--- a/src/_ffab-icon.scss
+++ b/src/_ffab-icon.scss
@@ -1,0 +1,13 @@
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Icon (ffab)
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+@mixin ffab-icon {
+  .#{$ffab-css-prefix}::before {
+    @include fa-icon;
+    line-height: 1;
+    position: absolute;
+    transition: color inherit;
+    z-index: 2;
+  }
+}

--- a/src/_ffab-overlay.scss
+++ b/src/_ffab-overlay.scss
@@ -2,15 +2,12 @@
 // Overlay (ffab)
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-@mixin ffab-overlay-width($width: default) {
+@mixin ffab-overlay(
+  $border-width: $ffab-border-width,
+  $background: $ffab-overlay-background-color
+  ) {
   &::after {
-    width: ffab-width($width);
-  }
-}
-
-@mixin ffab-overlay($border-width: 0) {
-  &::after {
-    background-color: $ffab-overlay-background-color;
+    background-color: $background;
     border: $border-width solid currentColor;
     content: '';
     height: 110%;
@@ -19,5 +16,11 @@
     transition: all $ffab-transition-speed;
     width: ffab-width(default);
     z-index: 1;
+  }
+}
+
+@mixin ffab-overlay-default {
+  .#{$ffab-css-prefix} {
+    @include ffab-overlay;
   }
 }

--- a/src/_ffab-position.scss
+++ b/src/_ffab-position.scss
@@ -1,16 +1,20 @@
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-// Positions (ffab)
+// Position (ffab)
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-@mixin ffab-position($position, $size: default) {
+@mixin ffab-position($position: $ffab-default-position, $size: default) {
+  &::after {
+    width: ffab-width($size);
+  }
+
   @if $position == 'before' {
     padding-left: ffab-width($size);
 
-    &:before {
+    &::before {
       left: get-side($button-padding, left);
     }
 
-    &:after {
+    &::after {
       left: -#{$ffab-angle}px;
       transform: skewX(#{$ffab-angle}deg);
       transform-origin: left;
@@ -18,11 +22,11 @@
   } @else if $position == 'after' {
     padding-right: ffab-width($size);
 
-    &:before {
+    &::before {
       right: get-side($button-padding, right);
     }
 
-    &:after {
+    &::after {
       right: -#{$ffab-angle}px;
       transform: skewX(-#{$ffab-angle}deg);
       transform-origin: right;
@@ -32,6 +36,11 @@
 
 // Classes
 @mixin ffab-positions {
+  // Without position class
+  .#{$ffab-css-prefix}:not(.before):not(.after) {
+    @include ffab-position;
+  }
+
   .#{$ffab-css-prefix}.after {
     @include ffab-position('after');
   }
@@ -40,23 +49,19 @@
     @include ffab-position('before');
   }
 
-  .#{$ffab-css-prefix}:not(.before):not(.after) {
-    @include ffab-position($ffab-default-position);
-  }
-
   @each $size, $value in $button-sizes {
     @if $size != default {
-      &.#{$size}:not(.before):not(.after) {
+      // Without position class
+      .#{$ffab-css-prefix}.#{$size}:not(.before):not(.after) {
         @include ffab-position($ffab-default-position, $size);
-        @include ffab-overlay-width($size);
       }
-      &.#{$size}.after {
+
+      .#{$ffab-css-prefix}.#{$size}.after {
         @include ffab-position('after', $size);
-        @include ffab-overlay-width($size);
       }
-      &.#{$size}.before {
+
+      .#{$ffab-css-prefix}.#{$size}.before {
         @include ffab-position('before', $size);
-        @include ffab-overlay-width($size);
       }
     }
   }

--- a/src/_ffab-transitions.scss
+++ b/src/_ffab-transitions.scss
@@ -5,10 +5,12 @@
 @mixin ffab-transition($behavior) {
   @if $behavior == 'cover' {
     transform: skewX(0deg) !important;
-    width: 112% !important;
+    width: 114% !important;
   } @else if $behavior == 'remove' {
     transform: skewX(0deg) !important;
     width: 0% !important;
+  } @else if $behavior == 'static' {
+    // Don't animate
   } @else {
     @warn "An valid transition behavior is required (cover or remove)";
   }

--- a/src/_ffab-variables.scss
+++ b/src/_ffab-variables.scss
@@ -25,7 +25,7 @@ $ffab-transition-speed: 0.3s !default;
 
 /// Defines the default behavior of the :hover transition
 /// @type String
-/// @options 'remove', 'cover' or 'none'
+/// @options 'remove', 'cover' or 'static'
 $ffab-transition-behavior: 'remove' !default;
 
 /// Defines the background of the icon overlay

--- a/src/_ffab.scss
+++ b/src/_ffab.scss
@@ -4,27 +4,25 @@
 
 @import 'ffab-variables';
 @import 'ffab-functions';
-@import 'ffab-utilities';
+
 @import 'ffab-base';
+@import 'ffab-bordered';
+@import 'ffab-hollow';
 @import 'ffab-icon';
 @import 'ffab-overlay';
+@import 'ffab-position';
 @import 'ffab-transitions';
-@import 'ffab-positions';
+@import 'ffab-utilities';
 
 @mixin ffab-everything {
-  @include ffab-transitions;
-  @include ffab-utilities;
   @include ffab-base;
   @include ffab-icon;
   @include ffab-positions;
+  @include ffab-overlay-default;
+  @include ffab-transitions;
 
-  .#{$ffab-css-prefix} {
-    @include ffab-overlay($ffab-border-width);
-    @include ffab-transitions;
+  @include ffab-utilities;
 
-    &.hollow,
-    &.bordered {
-      @include ffab-overlay(1px);
-    }
-  }
+  @include ffab-bordered;
+  @include ffab-hollow;
 }

--- a/src/_ffab.scss
+++ b/src/_ffab.scss
@@ -6,6 +6,7 @@
 @import 'ffab-functions';
 @import 'ffab-utilities';
 @import 'ffab-base';
+@import 'ffab-icon';
 @import 'ffab-overlay';
 @import 'ffab-transitions';
 @import 'ffab-positions';
@@ -13,11 +14,11 @@
 @mixin ffab-everything {
   @include ffab-transitions;
   @include ffab-utilities;
+  @include ffab-base;
+  @include ffab-icon;
   @include ffab-positions;
 
   .#{$ffab-css-prefix} {
-    @include ffab-base;
-    @include ffab-icon;
     @include ffab-overlay($ffab-border-width);
     @include ffab-transitions;
 


### PR DESCRIPTION
**Refactoring:**
- Better separate concerns by splitting up `base` and `icon` mixins.
- Putting hollowed and bordered concerns in their own files.
- Added the `ffab-prefix` to the components rather than nesting them in a `ffab-prefix` parent class. This will make it easier to call mixins by themselves without worrying about leaked styles or missing class names.

**Fixed Bugs:**
- Utility classes were leaking outside the expected scope causing the class names like `.small` to produce side effects on non-related elements.
- Hollow buttons had a background color on overlay (which made it not truely hollow).
- Fix animation timing on the hollow button's icon and border not being in sync with the button's icon and border.
- Allow "static" to be set in the `$ffab-transition-behavior`.
